### PR TITLE
fix github link (github.io -> github.com)

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -3,7 +3,7 @@
     "url": "https://rongying.co",
     "title": "My Blog",
     "description": "Welcome to my blog",
-    "github": "https://github.io/kohrongying",
+    "github": "https://github.com/kohrongying",
     "twitter": "",
     "linkedin": "https://www.linkedin.com/in/rongyingkoh/"
 }


### PR DESCRIPTION
Hello! The github pages link didn't actually connect to anything related to you, so I suspect you'd prefer it to be your github account. Please disregard if this was intentional 🙏